### PR TITLE
How nx affected apps works

### DIFF
--- a/_posts/2018-03-13-how-nx-affected-apps-works.md
+++ b/_posts/2018-03-13-how-nx-affected-apps-works.md
@@ -15,11 +15,11 @@ disqus: true
 cover: 'assets/images/cover/cover10.jpg'
 ---
 
-Nx from Nrwl is a collection of tools that can help us build Angular applications using a monorepo and all the benefits that brings. In essence, Nx is a set of schematics that work on top of the @angular/cli. These schematics can be used to create apps and libs inside of a single @angular/cli project. Having multiple apps is supported by default and Nx leverages this feature and makes the process a little easier.
+Nx from Nrwl is a collection of tools that can help us build Angular applications using a monorepo. In essence, Nx is a set of <a href="https://blog.angular.io/schematics-an-introduction-dc1dfbc2a2b2" target="_blank">schematics</a> that work on top of the @angular/cli. These schematics can be used to create apps and libs inside of a single @angular/cli project. Having multiple apps is supported by default and Nx leverages this feature and makes the process a little easier.
 
-This post however is not about the basic working of Nx. For that, go to their official website <a href="https://nrwl.io/nx" target="_blank">here</a> or watch this <a target="_blank" href="https://www.youtube.com/watch?v=bMkKz8AedHc">very informative talk</a> by <a href="https://twitter.com/MrJamesHenry">James Henry</a> at NgVikings.
+This post however is not about the basic working of Nx. If you want to learn more about Nx itself, go to their official website <a href="https://nrwl.io/nx" target="_blank">here</a> or watch this <a target="_blank" href="https://www.youtube.com/watch?v=bMkKz8AedHc">very informative talk</a> by <a href="https://twitter.com/MrJamesHenry">James Henry</a> at NgVikings.
 
-This post will cover a different aspect of Nx. When all your applications are in the same repository, this poses some problems for your CI environment. Whenever a PR is merged into the master, the CI environment must rebuild your applications and ideally publish them to your DEV environment. But how do you handle it if you have a lot of apps in the same monorepo and you only want to build the apps that were affected by a certain PR? Nx provides us with a script to handle this situation. 
+This post will cover a different aspect of Nx. When all our applications are in the same repository, this poses some problems for your CI environment. Whenever a PR is merged into the master, the CI environment must rebuild your applications and ideally publish them to your DEV environment. But how do we handle it if we have a lot of apps in the same monorepo and we only want to build the apps that were affected by a certain PR? Nx provides us with a script to handle this situation. 
 
 ## Problem description
 
@@ -27,7 +27,7 @@ Let's take a look at the following Nx workspace. It has 2 apps and 2 libs.
 
 ![nx-workspace-image](https://www.dropbox.com/s/4qohmskumvwa8k2/Screenshot%202018-03-13%2019.04.20.png?raw=1)
 
-As you can see 'app1' depends on 'lib1' and 'lib2' and 'app2' only depends on 'lib1'. When we change something to 'lib2' we only need to rebuild our 'app1'. Nx provides us with a script that will, based on two git commit hashes, tell us all the apps that need to be build. You can run the script like this:
+As we can see 'app1' depends on 'lib1' and 'lib2' and 'app2' only depends on 'lib1'. When we change something to 'lib2' we only need to rebuild our 'app1'. Nx provides us with a script that will, based on two git commit hashes, tell us all the apps that need to be build. You can run the script like this:
 
 ```bash
 ./node_modules/.bin/nx affected apps SHA1 SHA2

--- a/_posts/2018-03-13-how-nx-affected-apps-works.md
+++ b/_posts/2018-03-13-how-nx-affected-apps-works.md
@@ -15,7 +15,7 @@ disqus: true
 cover: 'assets/images/cover/cover10.jpg'
 ---
 
-Nx from Nrwl is a collection of tools that can help us build Angular applications using a monorepo and all the benefits that brings. In essence, Nx is a set of schematics that work on top of the @angular/cli. These schematics can be used to create apps and libs inside of a single @angular/cli project, which is supported by default. Nx leverages this feature and makes the process a little easier.
+Nx from Nrwl is a collection of tools that can help us build Angular applications using a monorepo and all the benefits that brings. In essence, Nx is a set of schematics that work on top of the @angular/cli. These schematics can be used to create apps and libs inside of a single @angular/cli project. Having multiple apps is supported by default and Nx leverages this feature and makes the process a little easier.
 
 This post however is not about the basic working of Nx. For that, go to their official website <a href="https://nrwl.io/nx" target="_blank">here</a> or watch this <a target="_blank" href="https://www.youtube.com/watch?v=bMkKz8AedHc">very informative talk</a> by <a href="https://twitter.com/MrJamesHenry">James Henry</a> at NgVikings.
 
@@ -72,7 +72,7 @@ export function touchedProjects(projects: ProjectNode[], touchedFiles: string[])
   });
 }
 ```
-This will give us all the projects that have files that have changed, aka the 'touchedProjects'.
+This will give us all the projects that have files that have changed, a.k.a. the 'touchedProjects'.
 
 ### Identifying all the apps
 
@@ -182,7 +182,7 @@ We found the files that were changed and to which projects they belong to. We fi
   }
 ```
 
-There is an interesting part in this snippet. There is a check to see if 'null' is in the 'touchedProjects'. This happens when there is a change to a file that is changed outside of the 'apps' or 'libs' directory. This can happen if the package.json file has been updated. In that case, every 'app' needs to be rebuild.
+There is an interesting part in this snippet. There is a check to see if 'null' is in the 'touchedProjects'. This happens when there is a change to a file outside of the 'apps' or 'libs' directory. This can happen if, for example, the package.json file has been updated. In that case, every 'app' needs to be rebuild.
 
 Finally, we can look at the `hasDependencyOnTouchedProjects` function.
 
@@ -203,9 +203,11 @@ function hasDependencyOnTouchedProjects(project: string, touchedProjects: string
 }
 ```
 
+Using recursion, they cross-reference the affected files and the projects they belong to with the dependencies all the projects have. This will return a list of all the apps that need to build.
+
 ### Conclusion
 
-Using git, typescript and a little javascript code, the guys at Nx created a script that can help us to only rebuild apps that are needed by a certain change.
+Using git, typescript and a little javascript code, the guys at Nx created a script that can help us to only rebuild apps that are affected by a PR reducing the build time on our CI environments.
 
 
 

--- a/_posts/2018-03-13-how-nx-affected-apps-works.md
+++ b/_posts/2018-03-13-how-nx-affected-apps-works.md
@@ -1,5 +1,5 @@
 ---
-title: Understanding how Nx identifies updated apps
+title: Nx on your CI, how does it work?
 published: true
 author: kwintenp
 description: A deep dive into the implementation of how Nx knows which apps are affected by a PR

--- a/_posts/2018-03-13-how-nx-affected-apps-works.md
+++ b/_posts/2018-03-13-how-nx-affected-apps-works.md
@@ -1,0 +1,85 @@
+---
+title: How does nx know which apps are affected
+published: true
+author: kwintenp
+description: A deep dive into the implementation of how nx knows which apps are affected by a PR
+layout: post
+navigation: True
+date:   2018-03-13
+tags: Angular Nx
+subclass: 'post'
+categories: 'kwintenp'
+logo: 'assets/images/strongbrewlogo.png'
+published: true
+disqus: true
+cover: 'assets/images/cover/cover10.jpg'
+---
+
+Nx from Nrwl is a collection of tools that can help us build Angular applications using the monorepo approach used at google. In essense, Nx is a set of schematics that work on top of the @angular/cli. These schematics can be used to create apps and libs inside of a single @angular/cli project, which is supported by default. Nx leverages this feature and makes the process a litlle easier.
+
+This post however is not about the basic working of Nx. For that, go to their official website <a href="https://nrwl.io/nx" target="_blank">here</a> or watch this <a target="_blank" href="https://www.youtube.com/watch?v=bMkKz8AedHc">very informative talk</a> by <a href="https://twitter.com/MrJamesHenry">James Henry</a> at NgVikings.
+
+This post will cover a different aspect of Nx. When all your applications are in the same repository, this poses some problems for your CI environment. Whenever a PR is merged into the master, the CI environment must rebuild your applications and ideally publish them to your DEV environment. But how do you handle it if you have a lot of apps in the same monorepo and you only want to build the apps that were affected by a certain PR? Nx provides us with a script to handle this situation. 
+
+## Problem description
+
+Let's take a look at the following Nx workspace. It has 2 apps and 2 libs.
+
+![nx-workspace-image](https://www.dropbox.com/s/4qohmskumvwa8k2/Screenshot%202018-03-13%2019.04.20.png?raw=1)
+
+As you can see 'app1' depends on 'lib1' and 'lib2' and 'app2' only depends on 'lib1'. So if, in the case we changed something to 'lib2' we only need to rebuild our 'app1'. Nx provides us with a script that will, based on two git commit hashes, tell us all the apps that need to be build. In this post, we will take a look at the script they use to accomplish this.
+
+-- insert the script --
+
+## How do they know what apps to build
+
+### Knowing what files are changed
+
+To know the files that need to be changed, they leverage the 'git diff' command. Let's look at the code:
+
+```typescript
+function getFilesFromShash(sha1: string, sha2: string): string[] {
+  return execSync(`git diff --name-only ${sha1} ${sha2}`)
+    .toString('utf-8')
+    .split('\n')
+    .map(a => a.trim())
+    .filter(a => a.length > 0);
+}
+```
+
+The 'git diff' command returns all the files that have changed between two commits. This is transformed into a list of files.
+
+### Identifying all the apps
+
+Next step is identifying the different apps of the project. For this, they simply parse the '.angular-cli.json' file which has an entry with all the apps.
+
+```typescript
+export function getAffectedApps(touchedFiles: string[]): string[] {
+  const config = JSON.parse(fs.readFileSync('.angular-cli.json', 'utf-8'));
+  const projects = getProjectNodes(config);
+  
+  ...
+} 
+
+export function getProjectNodes(config) {
+  return (config.apps ? config.apps : []).filter(p => p.name !== '$workspaceRoot').map(p => {
+    return {
+      name: p.name,
+      root: p.root,
+      type: p.root.startsWith('apps/') ? ProjectType.app : ProjectType.lib,
+      files: allFilesInDir(path.dirname(p.root))
+    };
+  });
+}
+```
+They fetch all the apps, loop over them, and create an object containing information about this app, the name, the root folder, is it a real App or a Lib and all the files it holds.
+
+
+
+
+
+
+
+
+
+

--- a/_posts/2018-03-13-how-nx-affected-apps-works.md
+++ b/_posts/2018-03-13-how-nx-affected-apps-works.md
@@ -15,7 +15,7 @@ disqus: true
 cover: 'assets/images/cover/cover10.jpg'
 ---
 
-Nx from Nrwl is a collection of tools that can help us build Angular applications using a monorepo and all the benefits that brings. In essense, Nx is a set of schematics that work on top of the @angular/cli. These schematics can be used to create apps and libs inside of a single @angular/cli project, which is supported by default. Nx leverages this feature and makes the process a little easier.
+Nx from Nrwl is a collection of tools that can help us build Angular applications using a monorepo and all the benefits that brings. In essence, Nx is a set of schematics that work on top of the @angular/cli. These schematics can be used to create apps and libs inside of a single @angular/cli project, which is supported by default. Nx leverages this feature and makes the process a little easier.
 
 This post however is not about the basic working of Nx. For that, go to their official website <a href="https://nrwl.io/nx" target="_blank">here</a> or watch this <a target="_blank" href="https://www.youtube.com/watch?v=bMkKz8AedHc">very informative talk</a> by <a href="https://twitter.com/MrJamesHenry">James Henry</a> at NgVikings.
 
@@ -27,7 +27,7 @@ Let's take a look at the following Nx workspace. It has 2 apps and 2 libs.
 
 ![nx-workspace-image](https://www.dropbox.com/s/4qohmskumvwa8k2/Screenshot%202018-03-13%2019.04.20.png?raw=1)
 
-As you can see 'app1' depends on 'lib1' and 'lib2' and 'app2' only depends on 'lib1'. So when we changed something to 'lib2' we only need to rebuild our 'app1'. Nx provides us with a script that will, based on two git commit hashes, tell us all the apps that need to be build. You can run the script like this:
+As you can see 'app1' depends on 'lib1' and 'lib2' and 'app2' only depends on 'lib1'. When we change something to 'lib2' we only need to rebuild our 'app1'. Nx provides us with a script that will, based on two git commit hashes, tell us all the apps that need to be build. You can run the script like this:
 
 ```bash
 ./node_modules/.bin/nx affected apps SHA1 SHA2


### PR DESCRIPTION
Blog on a script that nx build to know the affected apps by a PR in the monorepo. This way you only need to build the apps that have been affected. 
This blog looks at the script to see how it works.