### PR TITLE
add url to config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,7 @@ language: 'en-uk'
 name: 'Strongbrew'
 description: ""
 
+url: https://blog.strongbrew.io
 short_url: 'blog.strongbrew.io'
 google_analytics: UA-112030289-1
 disqus_brecht: brechtbilliet


### PR DESCRIPTION
Hi 👋 

I noticed that when you wanted to share a post, the link wasn't included in tweet.
This should fix that for you 😄 

In dev mode you wouldn't have noticed this because it auto sets the url to your localhost.